### PR TITLE
ct-ng download mirror patches for 'isl' and 'expat' dependencies

### DIFF
--- a/ct-ng/alphaev4-unknown-linux-gnu.config
+++ b/ct-ng/alphaev4-unknown-linux-gnu.config
@@ -607,7 +607,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/alphaev5-unknown-linux-gnu.config
+++ b/ct-ng/alphaev5-unknown-linux-gnu.config
@@ -597,7 +597,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/alphaev6-unknown-linux-gnu.config
+++ b/ct-ng/alphaev6-unknown-linux-gnu.config
@@ -597,7 +597,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/alphaev7-unknown-linux-gnu.config
+++ b/ct-ng/alphaev7-unknown-linux-gnu.config
@@ -597,7 +597,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arc-unknown-elf.config
+++ b/ct-ng/arc-unknown-elf.config
@@ -493,7 +493,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arc-unknown-linux-uclibc.config
+++ b/ct-ng/arc-unknown-linux-uclibc.config
@@ -586,7 +586,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arcbe-unknown-elf.config
+++ b/ct-ng/arcbe-unknown-elf.config
@@ -499,7 +499,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arcbe-unknown-linux-uclibc.config
+++ b/ct-ng/arcbe-unknown-linux-uclibc.config
@@ -566,7 +566,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm-unknown-elf.config
+++ b/ct-ng/arm-unknown-elf.config
@@ -535,7 +535,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm-unknown-linux-musleabi.config
+++ b/ct-ng/arm-unknown-linux-musleabi.config
@@ -584,7 +584,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm-unknown-linux-uclibceabi.config
+++ b/ct-ng/arm-unknown-linux-uclibceabi.config
@@ -603,7 +603,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64-unknown-elf.config
+++ b/ct-ng/arm64-unknown-elf.config
@@ -520,7 +520,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64-unknown-linux-musl.config
+++ b/ct-ng/arm64-unknown-linux-musl.config
@@ -574,7 +574,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64-unknown-linux-uclibc.config
+++ b/ct-ng/arm64-unknown-linux-uclibc.config
@@ -606,7 +606,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64eb-unknown-elf.config
+++ b/ct-ng/arm64eb-unknown-elf.config
@@ -520,7 +520,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64eb-unknown-linux-gnu.config
+++ b/ct-ng/arm64eb-unknown-linux-gnu.config
@@ -609,7 +609,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64eb-unknown-linux-musl.config
+++ b/ct-ng/arm64eb-unknown-linux-musl.config
@@ -574,7 +574,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/arm64eb-unknown-linux-uclibc.config
+++ b/ct-ng/arm64eb-unknown-linux-uclibc.config
@@ -606,7 +606,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armeb-unknown-elf.config
+++ b/ct-ng/armeb-unknown-elf.config
@@ -535,7 +535,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armeb-unknown-linux-gnueabi.config
+++ b/ct-ng/armeb-unknown-linux-gnueabi.config
@@ -621,7 +621,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armeb-unknown-linux-musleabi.config
+++ b/ct-ng/armeb-unknown-linux-musleabi.config
@@ -584,7 +584,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armeb-unknown-linux-uclibceabi.config
+++ b/ct-ng/armeb-unknown-linux-uclibceabi.config
@@ -603,7 +603,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armebv6-unknown-linux-gnueabi.config
+++ b/ct-ng/armebv6-unknown-linux-gnueabi.config
@@ -621,7 +621,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armebv6-unknown-linux-musleabi.config
+++ b/ct-ng/armebv6-unknown-linux-musleabi.config
@@ -584,7 +584,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armebv6-unknown-linux-uclibceabi.config
+++ b/ct-ng/armebv6-unknown-linux-uclibceabi.config
@@ -603,7 +603,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armv6-unknown-linux-gnueabi.config
+++ b/ct-ng/armv6-unknown-linux-gnueabi.config
@@ -621,7 +621,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armv6-unknown-linux-musleabi.config
+++ b/ct-ng/armv6-unknown-linux-musleabi.config
@@ -584,7 +584,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/armv6-unknown-linux-uclibceabi.config
+++ b/ct-ng/armv6-unknown-linux-uclibceabi.config
@@ -603,7 +603,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/avr.config
+++ b/ct-ng/avr.config
@@ -476,7 +476,7 @@ CT_EXPAT_V_4_1=y
 # CT_EXPAT_V_2_2 is not set
 # CT_EXPAT_NO_VERSIONS is not set
 CT_EXPAT_VERSION="2.4.1"
-CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
+CT_EXPAT_MIRRORS="https://github.com/libexpat/libexpat/releases/download/R_2_4_1"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_FORMATS=".tar.bz2"
@@ -515,7 +515,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/i386-unknown-elf.config
+++ b/ct-ng/i386-unknown-elf.config
@@ -499,7 +499,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/i486-unknown-elf.config
+++ b/ct-ng/i486-unknown-elf.config
@@ -499,7 +499,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/i586-unknown-elf.config
+++ b/ct-ng/i586-unknown-elf.config
@@ -499,7 +499,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/i686-unknown-elf.config
+++ b/ct-ng/i686-unknown-elf.config
@@ -499,7 +499,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/m68k-unknown-elf.config
+++ b/ct-ng/m68k-unknown-elf.config
@@ -494,7 +494,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/microblaze-xilinx-linux-gnu.config
+++ b/ct-ng/microblaze-xilinx-linux-gnu.config
@@ -615,7 +615,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/microblazeel-xilinx-linux-gnu.config
+++ b/ct-ng/microblazeel-xilinx-linux-gnu.config
@@ -615,7 +615,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/mips-unknown-o32.config
+++ b/ct-ng/mips-unknown-o32.config
@@ -518,7 +518,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/mips64-unknown-n64.config
+++ b/ct-ng/mips64-unknown-n64.config
@@ -516,7 +516,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/mips64el-unknown-n64.config
+++ b/ct-ng/mips64el-unknown-n64.config
@@ -516,7 +516,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/mipsel-unknown-o32.config
+++ b/ct-ng/mipsel-unknown-o32.config
@@ -515,7 +515,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/moxie-none-elf.config
+++ b/ct-ng/moxie-none-elf.config
@@ -505,7 +505,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/moxie-none-moxiebox.config
+++ b/ct-ng/moxie-none-moxiebox.config
@@ -599,7 +599,7 @@ CT_EXPAT_PATCH_ORDER="global"
 CT_EXPAT_V_4_1=y
 # CT_EXPAT_V_2_2 is not set
 CT_EXPAT_VERSION="2.4.1"
-CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
+CT_EXPAT_MIRRORS="https://github.com/libexpat/libexpat/releases/download/R_2_4_1"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_FORMATS=".tar.bz2"
@@ -652,7 +652,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/moxieeb-none-elf.config
+++ b/ct-ng/moxieeb-none-elf.config
@@ -505,7 +505,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/nios2-unknown-elf.config
+++ b/ct-ng/nios2-unknown-elf.config
@@ -496,7 +496,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/nios2-unknown-linux-gnu.config
+++ b/ct-ng/nios2-unknown-linux-gnu.config
@@ -601,7 +601,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/patch.sh.in
+++ b/ct-ng/patch.sh.in
@@ -42,6 +42,9 @@ fi
 # Update to 2.4.1, fixes security issues.
 buffer=$(echo "$buffer" | sed 's/^^EXPAT_V_OLD^$/^EXPAT_V_NEW^/')
 buffer=$(echo "$buffer" | sed 's/^CT_EXPAT_VERSION="^EXPAT_OLD^"$/CT_EXPAT_VERSION="^EXPAT_NEW^"/')
+# Fix download mirrors
+buffer=$(echo "$buffer" | sed -e 's|CT_ISL_MIRRORS=.*$|CT_ISL_MIRRORS="https://libisl.sourceforge.io"|')
+buffer=$(echo "$buffer" | sed -e 's|CT_EXPAT_MIRRORS=.*$|CT_EXPAT_MIRRORS="https://github.com/libexpat/libexpat/releases/download/R_^EXPAT_DL_NEW^"|')
 
 # Write to file.
 echo "$buffer" > "$DST"

--- a/ct-ng/ppc-unknown-elf.config
+++ b/ct-ng/ppc-unknown-elf.config
@@ -511,7 +511,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppc-unknown-linux-musl.config
+++ b/ct-ng/ppc-unknown-linux-musl.config
@@ -575,7 +575,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppc-unknown-linux-uclibc.config
+++ b/ct-ng/ppc-unknown-linux-uclibc.config
@@ -617,7 +617,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppc64-unknown-linux-musl.config
+++ b/ct-ng/ppc64-unknown-linux-musl.config
@@ -572,7 +572,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppc64-unknown-linux-uclibc.config
+++ b/ct-ng/ppc64-unknown-linux-uclibc.config
@@ -614,7 +614,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppc64le-unknown-linux-musl.config
+++ b/ct-ng/ppc64le-unknown-linux-musl.config
@@ -572,7 +572,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppc64le-unknown-linux-uclibc.config
+++ b/ct-ng/ppc64le-unknown-linux-uclibc.config
@@ -614,7 +614,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppcle-unknown-elf.config
+++ b/ct-ng/ppcle-unknown-elf.config
@@ -511,7 +511,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppcle-unknown-linux-gnu.config
+++ b/ct-ng/ppcle-unknown-linux-gnu.config
@@ -617,7 +617,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppcle-unknown-linux-musl.config
+++ b/ct-ng/ppcle-unknown-linux-musl.config
@@ -575,7 +575,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/ppcle-unknown-linux-uclibc.config
+++ b/ct-ng/ppcle-unknown-linux-uclibc.config
@@ -617,7 +617,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/s390-unknown-linux-gnu.config
+++ b/ct-ng/s390-unknown-linux-gnu.config
@@ -590,7 +590,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/sh-unknown-elf.config
+++ b/ct-ng/sh-unknown-elf.config
@@ -516,7 +516,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/sh3-unknown-linux-gnu.config
+++ b/ct-ng/sh3-unknown-linux-gnu.config
@@ -610,7 +610,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/sh3be-unknown-linux-gnu.config
+++ b/ct-ng/sh3be-unknown-linux-gnu.config
@@ -608,7 +608,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/sh4be-unknown-linux-gnu.config
+++ b/ct-ng/sh4be-unknown-linux-gnu.config
@@ -370,7 +370,9 @@ CT_GLIBC_USE="GLIBC"
 CT_GLIBC_PKG_NAME="glibc"
 CT_GLIBC_SRC_RELEASE=y
 CT_GLIBC_PATCH_ORDER="global"
-CT_GLIBC_V_2_29=y
+CT_GLIBC_V_2_31=y
+# CT_GLIBC_V_2_30 is not set
+# CT_GLIBC_V_2_29 is not set
 # CT_GLIBC_V_2_28 is not set
 # CT_GLIBC_V_2_27 is not set
 # CT_GLIBC_V_2_26 is not set
@@ -381,7 +383,7 @@ CT_GLIBC_V_2_29=y
 # CT_GLIBC_V_2_17 is not set
 # CT_GLIBC_V_2_12_1 is not set
 # CT_GLIBC_NO_VERSIONS is not set
-CT_GLIBC_VERSION="2.29"
+CT_GLIBC_VERSION="2.31"
 CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
 CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -470,12 +472,14 @@ CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 CT_GCC_PATCH_ORDER="global"
-CT_GCC_V_8=y
+CT_GCC_V_10=y
+# CT_GCC_V_9 is not set
+# CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
 # CT_GCC_V_5 is not set
 # CT_GCC_NO_VERSIONS is not set
-CT_GCC_VERSION="8.3.0"
+CT_GCC_VERSION="10.2.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -604,7 +608,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/sparc-unknown-elf.config
+++ b/ct-ng/sparc-unknown-elf.config
@@ -514,7 +514,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/sparc-unknown-linux-uclibc.config
+++ b/ct-ng/sparc-unknown-linux-uclibc.config
@@ -462,13 +462,15 @@ CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 CT_GCC_PATCH_ORDER="global"
-CT_GCC_V_8=y
+CT_GCC_V_10=y
+# CT_GCC_V_9 is not set
+# CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
 # CT_GCC_V_5 is not set
 # CT_GCC_V_4_9 is not set
 # CT_GCC_NO_VERSIONS is not set
-CT_GCC_VERSION="8.3.0"
+CT_GCC_VERSION="10.2.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -593,7 +595,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/x86_64-multilib-linux-musl.config
+++ b/ct-ng/x86_64-multilib-linux-musl.config
@@ -653,7 +653,7 @@ CT_EXPAT_V_4_1=y
 # CT_EXPAT_V_2_2 is not set
 # CT_EXPAT_NO_VERSIONS is not set
 CT_EXPAT_VERSION="2.4.1"
-CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
+CT_EXPAT_MIRRORS="https://github.com/libexpat/libexpat/releases/download/R_2_4_1"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_FORMATS=".tar.bz2"
@@ -708,7 +708,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/x86_64-unknown-elf.config
+++ b/ct-ng/x86_64-unknown-elf.config
@@ -499,7 +499,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/x86_64-unknown-linux-uclibc.config
+++ b/ct-ng/x86_64-unknown-linux-uclibc.config
@@ -607,7 +607,7 @@ CT_EXPAT_V_4_1=y
 # CT_EXPAT_V_2_2 is not set
 # CT_EXPAT_NO_VERSIONS is not set
 CT_EXPAT_VERSION="2.4.1"
-CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
+CT_EXPAT_MIRRORS="https://github.com/libexpat/libexpat/releases/download/R_2_4_1"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_FORMATS=".tar.bz2"
@@ -646,7 +646,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/x86_64-w64-mingw32.config
+++ b/ct-ng/x86_64-w64-mingw32.config
@@ -549,7 +549,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/ct-ng/xtensabe-unknown-linux-uclibc.config
+++ b/ct-ng/xtensabe-unknown-linux-uclibc.config
@@ -599,7 +599,7 @@ CT_ISL_V_0_20=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.20"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/setup.py
+++ b/setup.py
@@ -1641,6 +1641,7 @@ class ConfigureCommand(VersionCommand):
         replacements.append(('EXPAT_V_NEW', '\\n'.join(ct_expat)))
         replacements.append(('EXPAT_OLD', old_expat_version))
         replacements.append(('EXPAT_NEW', expat_version))
+        replacements.append(('EXPAT_DL_NEW', expat_version.replace('.','_')))
 
         self.configure(f'{patch}.in', patch, True, replacements)
 


### PR DESCRIPTION
See this issue for more details https://github.com/crosstool-ng/crosstool-ng/issues/1625